### PR TITLE
setup.py: fix extras_require for setuptools 36.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ setup(
     ],
     extras_require={
         'full': [
-            'lxml;platform_system!="Windows"',
             'feedparser',
             'selenium',
         ],
+        'full:platform_system!="Windows"': ['lxml'],
     },
     packages = find_packages(exclude=['test']),
     license = "MIT",


### PR DESCRIPTION
Install on linux fails with setuptools==36.2.0 (pypa/setuptools#1087)

```
Collecting weblib==0.1.24 (from -r test-requirements.txt (line 62))
  Downloading weblib-0.1.24.tar.gz
    Complete output from command python setup.py egg_info:
    error in weblib setup command: 'extras_require' requirements cannot include environment markers, in 'full': 'lxml; platform_system != "Windows"'
```